### PR TITLE
upgrade checks to use cdm_framework v0.0.2

### DIFF
--- a/general/source_control/dependabotprs/go.mod
+++ b/general/source_control/dependabotprs/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.12
 
 require (
 	github.com/google/go-github/v74 v74.0.0
-	github.com/iamsamd/cdm_framework v0.0.1
+	github.com/iamsamd/cdm_framework v0.0.2
 )
 
 require (

--- a/general/source_control/dependabotprs/go.sum
+++ b/general/source_control/dependabotprs/go.sum
@@ -7,6 +7,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/iamsamd/cdm_framework v0.0.1 h1:M2At4A8B16Lqjk3hMhPymrGi9bl3S8cAKEIVPbnaKTo=
 github.com/iamsamd/cdm_framework v0.0.1/go.mod h1:+Ah/VUGQOZylnVPsZtjt9JT1pNpMSOLs5JbxNiCx5kc=
+github.com/iamsamd/cdm_framework v0.0.2 h1:TnlMNdEbwJrbaDTjNjB4dGrEHHCUNtGKt/wcH7IlyUY=
+github.com/iamsamd/cdm_framework v0.0.2/go.mod h1:+Ah/VUGQOZylnVPsZtjt9JT1pNpMSOLs5JbxNiCx5kc=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Upgrades the checks to use v0.0.2 of the cdm_framework package.

This upgrade implements a change to the FailCheck function which causes the check to exit with code 2 on a legitimate fail, allowing the cli to determine whether a check failed due to an error or because the check failed legitimately. 